### PR TITLE
Show new comment in UI

### DIFF
--- a/src/Comment/CommentAdd/index.js
+++ b/src/Comment/CommentAdd/index.js
@@ -80,6 +80,23 @@ class CommentAdd extends Component {
       <Mutation
         mutation={ADD_COMMENT}
         variables={{ body: value, subjectId: issue.id }}
+        optimisticResponse={{
+          addComment: {
+            __typename: 'Mutation',
+            commentEdge: {
+              __typename: 'IssueCommentEdge',
+              node: {
+                __typename: 'IssueComment',
+                id: new Date().getTime() + '',
+                author: {
+                  __typename: 'User',
+                  login: 'me'
+                },
+                bodyHTML: value
+              }
+            }
+          }
+        }}
         update={(client, data) => updateComments({
           repositoryOwner,
           repositoryName,

--- a/src/Comment/CommentAdd/index.js
+++ b/src/Comment/CommentAdd/index.js
@@ -23,13 +23,13 @@ class CommentAdd extends Component {
   };
 
   render() {
-    const { issueId } = this.props;
+    const { issue } = this.props;
     const { value } = this.state;
 
     return (
       <Mutation
         mutation={ADD_COMMENT}
-        variables={{ body: value, subjectId: issueId }}
+        variables={{ body: value, subjectId: issue.id }}
       >
         {(addComment, { data, loading, error }) => (
           <div>

--- a/src/Comment/CommentAdd/mutations.js
+++ b/src/Comment/CommentAdd/mutations.js
@@ -1,13 +1,16 @@
 import gql from 'graphql-tag';
 
+import ISSUECOMMENT_FRAGMENT from '../fragment';
+
 export const ADD_COMMENT = gql`
   mutation($subjectId: ID!, $body: String!) {
     addComment(input: { subjectId: $subjectId, body: $body }) {
       commentEdge {
         node {
-          body
+          ...issueComment
         }
       }
     }
   }
+  ${ISSUECOMMENT_FRAGMENT}
 `;

--- a/src/Comment/CommentList/index.js
+++ b/src/Comment/CommentList/index.js
@@ -68,7 +68,9 @@ const Comments = ({ repositoryOwner, repositoryName, issue }) => (
             fetchMore={fetchMore}
           />
 
-          <CommentAdd issueId={repository.issue.id} />
+          <CommentAdd
+            issue={issue}
+          />
         </Fragment>
       );
     }}

--- a/src/Comment/CommentList/index.js
+++ b/src/Comment/CommentList/index.js
@@ -70,6 +70,8 @@ const Comments = ({ repositoryOwner, repositoryName, issue }) => (
 
           <CommentAdd
             issue={issue}
+            repositoryOwner={repositoryOwner}
+            repositoryName={repositoryName}
           />
         </Fragment>
       );

--- a/src/Comment/CommentList/queries.js
+++ b/src/Comment/CommentList/queries.js
@@ -1,5 +1,7 @@
 import gql from 'graphql-tag';
 
+import ISSUECOMMENT_FRAGMENT from '../fragment';
+
 export const GET_COMMENTS_OF_ISSUE = gql`
   query(
     $repositoryOwner: String!
@@ -13,11 +15,7 @@ export const GET_COMMENTS_OF_ISSUE = gql`
         comments(first: 1, after: $cursor) {
           edges {
             node {
-              id
-              bodyHTML
-              author {
-                login
-              }
+              ...issueComment
             }
           }
           pageInfo {
@@ -28,4 +26,5 @@ export const GET_COMMENTS_OF_ISSUE = gql`
       }
     }
   }
+  ${ISSUECOMMENT_FRAGMENT}
 `;

--- a/src/Comment/fragment.js
+++ b/src/Comment/fragment.js
@@ -1,0 +1,11 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  fragment issueComment on IssueComment {
+    id
+    bodyHTML
+    author {
+      login
+    }
+  }
+`;


### PR DESCRIPTION
When a new comment is added, it now displays in the UI. It uses optimistic UI to immediately render the new comment, then updates based on the GraphQL mutation response. This fulfills this exercise:

https://www.robinwieruch.de/react-graphql-apollo-tutorial#exercise-commenting-feature

> Improve the AddComment component with the optimistic UI feature (perhaps read again the Apollo documentation about the optimistic UI with a list of items). A comment should show up in the list of comments, even if the request is pending.

## Known issues
### Missing author.login
The author's login isn't being fetched, so during the optimistic UI rendering and before the server responds to the `addComment` mutation, the author's login is displayed as `me`.
#### During optimistic UI:
![image](https://user-images.githubusercontent.com/504505/72198552-c857a000-33e3-11ea-99aa-6d373eb2ea59.png)
#### After server response
![image](https://user-images.githubusercontent.com/504505/72198555-d7d6e900-33e3-11ea-8960-ec12e4b22bb2.png)

---

### Paginating after new comment insertion
When paginating after a new comment is inserted, and when the newly inserted comment returns from the server through pagination, this results in an ID conflict:
![image](https://user-images.githubusercontent.com/504505/72198578-63e91080-33e4-11ea-8c93-356abe07b6ce.png)
This also results in a duplicate comment, even through they have the same ID.
#### To reproduce:
* Insert a new comment
* Keep clicking `More Comments` until the newly inserted comment appears a second time

Can you please suggest how we can remedy this problem?